### PR TITLE
Improve performance of timestamp conversion

### DIFF
--- a/intake_pcap/stream.py
+++ b/intake_pcap/stream.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from datetime import datetime
 
 import pandas as pd
 


### PR DESCRIPTION
Converting from a Unix epoch time using Pandas was 5x slower than Python. For 100k packets, the overall time went from 13.6s to 2.6s.